### PR TITLE
don't depend on version-query at runtime and during build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
       - run: pip install -r requirements_ci.txt
       - run: python -m coverage run --branch --source . -m unittest -v
       - run: python -m coverage report --show-missing
-      - run: codecov
+      - run: python -m codecov --token ${{ secrets.CODECOV_TOKEN }}
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,15 @@ pipeline {
 
   stages {
 
+    stage('Prepare') {
+      steps {
+        sh '''#!/usr/bin/env bash
+          set -Eeuxo pipefail
+          python3 -m build
+        '''
+      }
+    }
+
     stage('Lint') {
       environment {
         PYTHON_MODULES = "${env.PYTHON_PACKAGE} test *.py"

--- a/boilerplates/.gitignore
+++ b/boilerplates/.gitignore
@@ -1,0 +1,1 @@
+/bundled_version_query

--- a/boilerplates/_version.py
+++ b/boilerplates/_version.py
@@ -1,5 +1,0 @@
-"""Version of boilerplates package."""
-
-from version_query import predict_version_str
-
-VERSION = predict_version_str()

--- a/boilerplates/packaging_tests.py
+++ b/boilerplates/packaging_tests.py
@@ -83,10 +83,14 @@ def get_package_folder_name():
 class PackagingTests(unittest.TestCase):
     """Test if the boilerplate can actually create a valid package."""
 
+    pkg_name: t.Optional[str] = None
+    version: t.Optional[str] = None
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.pkg_name = get_package_folder_name()
+        cls.pkg_name = get_package_folder_name() if cls.pkg_name is None else cls.pkg_name
+        cls.version = find_version(cls.pkg_name) if cls.version is None else cls.version
 
     def test_expand_args_in_cwd(self):
         expanded_args = expand_args_by_globbing_items('*.py')
@@ -118,23 +122,20 @@ class PackagingTests(unittest.TestCase):
         self.assertFalse(pathlib.Path(temporary_folder).exists())
 
     def test_install_source_tar(self):
-        version = find_version(self.pkg_name)
         with tempfile.TemporaryDirectory() as temporary_folder:
             run_pip(
-                'install', '--prefix', temporary_folder, f'dist/*-{version}.tar.gz', glob=True)
+                'install', '--prefix', temporary_folder, f'dist/*-{self.version}.tar.gz', glob=True)
         self.assertFalse(pathlib.Path(temporary_folder).exists())
 
     def test_install_source_zip(self):
-        version = find_version(self.pkg_name)
         with tempfile.TemporaryDirectory() as temporary_folder:
-            run_pip('install', '--prefix', temporary_folder, f'dist/*-{version}.zip', glob=True)
+            run_pip('install', '--prefix', temporary_folder, f'dist/*-{self.version}.zip', glob=True)
         self.assertFalse(pathlib.Path(temporary_folder).exists())
 
     def test_install_wheel(self):
-        version = find_version(self.pkg_name)
         with tempfile.TemporaryDirectory() as temporary_folder:
             run_pip(
-                'install', '--prefix', temporary_folder, f'dist/*-{version}-*.whl', glob=True)
+                'install', '--prefix', temporary_folder, f'dist/*-{self.version}-*.whl', glob=True)
         self.assertFalse(pathlib.Path(temporary_folder).exists())
 
     def test_pip_error(self):

--- a/boilerplates/packaging_tests.py
+++ b/boilerplates/packaging_tests.py
@@ -129,7 +129,8 @@ class PackagingTests(unittest.TestCase):
 
     def test_install_source_zip(self):
         with tempfile.TemporaryDirectory() as temporary_folder:
-            run_pip('install', '--prefix', temporary_folder, f'dist/*-{self.version}.zip', glob=True)
+            run_pip(
+                'install', '--prefix', temporary_folder, f'dist/*-{self.version}.zip', glob=True)
         self.assertFalse(pathlib.Path(temporary_folder).exists())
 
     def test_install_wheel(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     'docutils ~= 0.20',
     'Pygments ~= 2.14',
     'setuptools >= 67.4',
-    'version-query ~= 1.5'
+    'version-query ~= 1.6'
 ]
 
 [tool.flake8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,11 @@
 requires = [
     'build >= 0.10',
     'docutils ~= 0.20',
+    'GitPython ~= 3.1',
+    'packaging >= 24.0',
     'Pygments ~= 2.14',
-    'setuptools >= 67.4',
-    'version-query ~= 1.6'
+    'semver >= 2.13, < 3.1',
+    'setuptools >= 67.4'
 ]
 
 [tool.flake8]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-version-query ~= 1.5

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,4 @@
 -r requirements_sentry.txt
 -r requirements_cli.txt
 -r requirements_git_repo_tests.txt
+version-query ~= 1.6

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,33 @@
 """Setup script for boilerplates package."""
 
-from version_query import predict_version_str
+import pathlib
+import shutil
+import tempfile
+
+import git
 
 import boilerplates.setup
+
+
+def prepare_local_version_query():
+    """Prepare local copy of version_query package to avoid circular dependency between packages."""
+    here = pathlib.Path(__file__).parent
+    module_path = here / 'boilerplates' / 'bundled_version_query'
+    if module_path.exists():
+        return
+    with tempfile.TemporaryDirectory() as temporary_path:
+        repo_path = pathlib.Path(temporary_path)
+        print(f'ensuring version-query repository is available locally at "{repo_path}"')
+        repo = git.Repo.clone_from('https://github.com/mbdevpl/version-query', repo_path)
+        repo.git.checkout('v1.6.1')
+        print(f'ensuring version_query module is available locally at "{module_path}"')
+        shutil.copytree(repo_path / 'version_query', module_path, dirs_exist_ok=True)
+
+
+prepare_local_version_query()
+
+# pylint: disable=wrong-import-position
+from boilerplates.bundled_version_query import predict_version_str
 
 VERSION = predict_version_str()
 

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,11 @@ def prepare_local_version_query():
         repo_path = pathlib.Path(temporary_path)
         print(f'ensuring version-query repository is available locally at "{repo_path}"')
         repo = git.Repo.clone_from('https://github.com/mbdevpl/version-query', repo_path)
-        repo.git.checkout('v1.6.1')
+        repo.git.checkout('v1.6.2')
         print(f'ensuring version_query module is available locally at "{module_path}"')
         shutil.copytree(repo_path / 'version_query', module_path, dirs_exist_ok=True)
+    for filename in ('_version.py', '__main__.py', 'main.py'):
+        module_path.joinpath(filename).unlink()
 
 
 prepare_local_version_query()

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,17 @@
 """Setup script for boilerplates package."""
 
+from version_query import predict_version_str
+
 import boilerplates.setup
+
+VERSION = predict_version_str()
 
 
 class Package(boilerplates.setup.Package):
     """Package metadata."""
 
     name = 'boilerplates'
+    version = VERSION
     description = 'Various boilerplates used in almost all of my Python packages.'
     url = 'https://github.com/mbdevpl/python-boilerplates'
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ def prepare_local_version_query():
 
 prepare_local_version_query()
 
-# pylint: disable=wrong-import-position
-from boilerplates.bundled_version_query import predict_version_str
+# pylint: disable = wrong-import-position
+from boilerplates.bundled_version_query import predict_version_str  # noqa: E402
 
 VERSION = predict_version_str()
 

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -1,7 +1,12 @@
 """Tests for packaging."""
 
+from version_query import predict_version_str
+
 import boilerplates.packaging_tests
+
+VERSION = predict_version_str()
 
 
 class Tests(boilerplates.packaging_tests.PackagingTests):
-    pass
+
+    version = VERSION

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -8,7 +8,6 @@ import tempfile
 import unittest
 
 import boilerplates.setup
-import boilerplates.packaging_tests
 
 _LOG = logging.getLogger(__name__)
 
@@ -68,8 +67,7 @@ class UnitTests(unittest.TestCase):
     """Test basic functionalities of the setup boilerplate."""
 
     def test_find_version(self):
-        result = boilerplates.setup.find_version(
-            boilerplates.packaging_tests.get_package_folder_name())
+        result = boilerplates.setup.find_version('.', 'setup')
         self.assertIsInstance(result, str)
 
     def test_find_packages(self):


### PR DESCRIPTION
Removing build dependency should fix #13, and removing runtime dependency should simplify installation.