### PR TITLE
Feature/expand sentry boilerplate

### DIFF
--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -20,11 +20,15 @@ _LOG = logging.getLogger(__name__)
 class Sentry:
     """Sentry configuration.
 
-    For each parameter, the value is taken from the environment variable if it is set, otherwise
-    from the class attribute if it is set.
+    For parameters 'dsn', 'release' and 'environment', the value is taken
+    from the environment variable if it is set, otherwise from the class
+    attribute if it is set.
 
     For each parameter, the name of the environment variable name is 'SENTRY_'
     followed by the parameter name in upper case.
+
+    The class attribute tags, if set, will be added to the scope of the
+    current Sentry SDK.
     """
 
     dsn: str

--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -50,6 +50,8 @@ class Sentry:
     traces_sample_rate: float = 1.0
     profiles_sample_rate: float = 1.0
 
+    tags: t.Dict[str, str] = {}
+
     @classmethod
     def _get_str_param(cls, param_name: str) -> t.Optional[str]:
         """Get a string parameter value by checking envvar first.
@@ -64,6 +66,19 @@ class Sentry:
         """Check if Sentry DSN parameter is set, thus if Sentry SDK should be initialised or not."""
         dsn = cls._get_str_param('dsn')
         return dsn is not None and len(dsn) > 0
+
+    @classmethod
+    def set_tags(cls, tags: t.Dict[str, str]):
+        """Set tags for the current scope."""
+        with sentry_sdk.configure_scope() as scope:
+            scope.set_tags(tags)
+
+    @classmethod
+    def remove_tags(cls, tags: t.List[str]):
+        """Remove tags from the current scope."""
+        with sentry_sdk.configure_scope() as scope:
+            for tag in tags:
+                scope.remove_tag(tag)
 
     @classmethod
     def init(cls, *args, **kwargs):
@@ -85,3 +100,5 @@ class Sentry:
             send_default_pii=cls.send_default_pii,
             default_integrations=cls.default_integrations,
             **kwargs)
+
+        cls.set_tags(cls.tags)

--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -41,6 +41,12 @@ class Sentry:
         sentry_sdk.integrations.threading.ThreadingIntegration()
     ]
 
+    debug: bool = False
+    attach_stacktrace: bool = False
+    shutdown_timeout: float = 2.0
+    send_default_pii: bool | None = None
+    default_integrations: bool = True
+
     traces_sample_rate: float = 1.0
     profiles_sample_rate: float = 1.0
 
@@ -67,9 +73,15 @@ class Sentry:
             return
         sentry_sdk.init(
             *args, dsn=cls._get_str_param('dsn'),
-            release=cls._get_str_param('release'), environment=cls._get_str_param('environment'),
+            release=cls._get_str_param('release'),
+            environment=cls._get_str_param('environment'),
             integrations=cls.integrations,
             traces_sample_rate=cls.traces_sample_rate,
             profiles_sample_rate=cls.profiles_sample_rate,
             enable_tracing=cls.profiles_sample_rate > 0,
+            debug=cls.debug,
+            attach_stacktrace=cls.attach_stacktrace,
+            shutdown_timeout=cls.shutdown_timeout,
+            send_default_pii=cls.send_default_pii,
+            default_integrations=cls.default_integrations,
             **kwargs)


### PR DESCRIPTION
# Changes made:

* Expose some more parameters for versatility.
   * I used the default parameters expected by the underlying sentry init method.
   * The following parameters were added:
     * debug
     * attach_stacktrace
     * send_default_pii
     * default_integrations
* Add ability to set tags in scope.
    * This allows for an easy way to set scope tags on initialisation.
    * One can also choose to set or remove tags after initialisation.