### PR TITLE
refactor of PR#19 "Feature/expand sentry boilerplate"

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,5 @@
 Copyright (c) 2023-2025 Mateusz Bysiek  https://mbdevpl.github.io/
+Copyright (c) 2025 Stian Hanssen  https://github.com/StianHanssen
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -20,11 +20,15 @@ _LOG = logging.getLogger(__name__)
 class Sentry:
     """Sentry configuration.
 
-    For each parameter, the value is taken from the environment variable if it is set, otherwise
-    from the class attribute if it is set.
+    For parameters 'dsn', 'release' and 'environment', the value is taken
+    from the environment variable if it is set, otherwise from the class
+    attribute if it is set.
 
     For each parameter, the name of the environment variable name is 'SENTRY_'
     followed by the parameter name in upper case.
+
+    The class attribute tags, if set, will be added to the scope of the
+    current Sentry SDK.
     """
 
     dsn: str

--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -67,7 +67,7 @@ class Sentry:
     shutdown_timeout: float = 2.0
     """Time in seconds to wait for pending events to be sent before shutdown."""
 
-    send_default_pii: bool | None = False
+    send_default_pii: t.Optional[bool] = False
     """If True, send personally identifiable information."""
 
     traces_sample_rate: float = 1.0

--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -29,26 +29,17 @@ class Sentry:
 
     The class attribute tags, if set, will be added to the global scope of the
     current Sentry SDK.
-
-    :cvar dsn: sentry DSN (Data Source Name) used to identify the project in sentry
-    :cvar release: release version of your application
-    :cvar environment: environment name (e.g., 'production', 'staging', 'development')
-    :cvar integrations: list of sentry SDK integrations to enable (default: argv, excepthook,
-        logging, modules, pure_eval, stdlib, threading)
-    :cvar debug: enable debug mode for the sentry SDK (default: False)
-    :cvar attach_stacktrace: attach stacktraces to messages (default: False)
-    :cvar shutdown_timeout: time in seconds to wait for pending events to be sent before
-        shutdown (default: 2.0)
-    :cvar send_default_pii: send personally identifiable information by default (default: None)
-    :cvar default_integrations: enable sentry's default integrations (default: True)
-    :cvar traces_sample_rate: percentage of transactions to sample (0.0 to 1.0) (default: 1.0)
-    :cvar profiles_sample_rate: percentage of transactions to profile (0.0 to 1.0) (default: 1.0)
-    :cvar tags: dictionary of tags to apply to all events (default: {})
     """
 
     dsn: str
+    """Sentry DSN (Data Source Name) used to identify the project in Sentry."""
+
     release: str
+    """Release version of your application."""
+
     environment: str
+    """Environment name (e.g., 'production', 'staging', 'development')."""
+
     integrations: t.List[sentry_sdk.integrations.Integration] = [
         sentry_sdk.integrations.argv.ArgvIntegration(),
         sentry_sdk.integrations.excepthook.ExcepthookIntegration(always_run=False),
@@ -59,17 +50,34 @@ class Sentry:
         sentry_sdk.integrations.stdlib.StdlibIntegration(),
         sentry_sdk.integrations.threading.ThreadingIntegration()
     ]
+    """Sentry SDK integrations to enable.
+
+    To configure integrations that are enabled by default, also add them to this list.
+    """
+
+    default_integrations: bool = True
+    """If true, enable Sentry's default integrations besides the ones set via 'integrations'."""
 
     debug: bool = False
+    """If True, enable debug mode for the Sentry SDK."""
+
     attach_stacktrace: bool = False
+    """If True, attach stacktraces to messages."""
+
     shutdown_timeout: float = 2.0
-    send_default_pii: bool | None = None
-    default_integrations: bool = True
+    """Time in seconds to wait for pending events to be sent before shutdown."""
+
+    send_default_pii: bool | None = False
+    """If True, send personally identifiable information."""
 
     traces_sample_rate: float = 1.0
+    """Ratio of transactions to sample (0.0 to 1.0)."""
+
     profiles_sample_rate: float = 1.0
+    """Ratio of transactions to profile (0.0 to 1.0)."""
 
     tags: t.Dict[str, str] = {}
+    """Tags to be added to all events."""
 
     @classmethod
     def _get_str_param(cls, param_name: str) -> t.Optional[str]:

--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -50,6 +50,8 @@ class Sentry:
     traces_sample_rate: float = 1.0
     profiles_sample_rate: float = 1.0
 
+    tags: t.Dict[str, str] = {}
+
     @classmethod
     def _get_str_param(cls, param_name: str) -> t.Optional[str]:
         """Get a string parameter value by checking envvar first.
@@ -64,6 +66,19 @@ class Sentry:
         """Check if Sentry DSN parameter is set, thus if Sentry SDK should be initialised or not."""
         dsn = cls._get_str_param('dsn')
         return dsn is not None and len(dsn) > 0
+
+    @classmethod
+    def set_tags(cls, tags: t.Dict[str, str]):
+        """Set tags for the current scope."""
+        with sentry_sdk.configure_scope() as scope:
+            scope.set_tags(tags)
+
+    @classmethod
+    def remove_tags(cls, tags: t.List[str]):
+        """Remove tags from the current scope."""
+        with sentry_sdk.configure_scope() as scope:
+            for tag in tags:
+                scope.remove_tag(tag)
 
     @classmethod
     def init(cls, *args, **kwargs):
@@ -85,3 +100,5 @@ class Sentry:
             send_default_pii=cls.send_default_pii,
             default_integrations=cls.default_integrations,
             **kwargs)
+
+        cls.set_tags(cls.tags)

--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -29,6 +29,21 @@ class Sentry:
 
     The class attribute tags, if set, will be added to the global scope of the
     current Sentry SDK.
+
+    :cvar dsn: sentry DSN (Data Source Name) used to identify the project in sentry
+    :cvar release: release version of your application
+    :cvar environment: environment name (e.g., 'production', 'staging', 'development')
+    :cvar integrations: list of sentry SDK integrations to enable (default: argv, excepthook,
+        logging, modules, pure_eval, stdlib, threading)
+    :cvar debug: enable debug mode for the sentry SDK (default: False)
+    :cvar attach_stacktrace: attach stacktraces to messages (default: False)
+    :cvar shutdown_timeout: time in seconds to wait for pending events to be sent before
+        shutdown (default: 2.0)
+    :cvar send_default_pii: send personally identifiable information by default (default: None)
+    :cvar default_integrations: enable sentry's default integrations (default: True)
+    :cvar traces_sample_rate: percentage of transactions to sample (0.0 to 1.0) (default: 1.0)
+    :cvar profiles_sample_rate: percentage of transactions to profile (0.0 to 1.0) (default: 1.0)
+    :cvar tags: dictionary of tags to apply to all events (default: {})
     """
 
     dsn: str
@@ -61,6 +76,9 @@ class Sentry:
         """Get a string parameter value by checking envvar first.
 
         Works only for 'dsn', 'release' or 'environment' parameters.
+
+        :param param_name: name of the parameter to get
+        :return: value of the parameter
         """
         assert param_name in ('dsn', 'release', 'environment'), param_name
         return os.environ.get(f'SENTRY_{param_name.upper()}', getattr(cls, param_name, None))

--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -27,7 +27,7 @@ class Sentry:
     For each parameter, the name of the environment variable name is 'SENTRY_'
     followed by the parameter name in upper case.
 
-    The class attribute tags, if set, will be added to the scope of the
+    The class attribute tags, if set, will be added to the global scope of the
     current Sentry SDK.
     """
 
@@ -72,19 +72,6 @@ class Sentry:
         return dsn is not None and len(dsn) > 0
 
     @classmethod
-    def set_tags(cls, tags: t.Dict[str, str]):
-        """Set tags for the current scope."""
-        with sentry_sdk.configure_scope() as scope:
-            scope.set_tags(tags)
-
-    @classmethod
-    def remove_tags(cls, tags: t.List[str]):
-        """Remove tags from the current scope."""
-        with sentry_sdk.configure_scope() as scope:
-            for tag in tags:
-                scope.remove_tag(tag)
-
-    @classmethod
     def init(cls, *args, **kwargs):
         """Initialise Sentry SDK."""
         if not cls.is_dsn_set():
@@ -105,4 +92,4 @@ class Sentry:
             default_integrations=cls.default_integrations,
             **kwargs)
 
-        cls.set_tags(cls.tags)
+        sentry_sdk.set_tags(cls.tags)

--- a/boilerplates/sentry.py
+++ b/boilerplates/sentry.py
@@ -41,6 +41,12 @@ class Sentry:
         sentry_sdk.integrations.threading.ThreadingIntegration()
     ]
 
+    debug: bool = False
+    attach_stacktrace: bool = False
+    shutdown_timeout: float = 2.0
+    send_default_pii: bool | None = None
+    default_integrations: bool = True
+
     traces_sample_rate: float = 1.0
     profiles_sample_rate: float = 1.0
 
@@ -67,9 +73,15 @@ class Sentry:
             return
         sentry_sdk.init(
             *args, dsn=cls._get_str_param('dsn'),
-            release=cls._get_str_param('release'), environment=cls._get_str_param('environment'),
+            release=cls._get_str_param('release'),
+            environment=cls._get_str_param('environment'),
             integrations=cls.integrations,
             traces_sample_rate=cls.traces_sample_rate,
             profiles_sample_rate=cls.profiles_sample_rate,
             enable_tracing=cls.profiles_sample_rate > 0,
+            debug=cls.debug,
+            attach_stacktrace=cls.attach_stacktrace,
+            shutdown_timeout=cls.shutdown_timeout,
+            send_default_pii=cls.send_default_pii,
+            default_integrations=cls.default_integrations,
             **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ class Package(boilerplates.setup.Package):
     version = VERSION
     description = 'Various boilerplates used in almost all of my Python packages.'
     url = 'https://github.com/mbdevpl/python-boilerplates'
+    author = 'Mateusz Bysiek, Stian Hanssen'
+    maintainer = 'Mateusz Bysiek'
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
A slight refactor of #19. To see only changes on top of the original PR, see here: https://github.com/StianHanssen/python-boilerplates/compare/feature/expand_sentry_boilerplate...mbdevpl:python-boilerplates:feature/expand_sentry_boilerplate

Changes:
* reorganise docstrings a bit
* make the code backwards compatible with Python 3.9
* add @StianHanssen to contributors list