### PR TITLE
modernize packaging tests boilerplate (don't run `setup.py` directly, don't create zip package, remove unnecessary dependencies)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - run: pip install build
+      - run: pip install build~=1.2
       - run: python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,7 @@ WORKDIR /home/user/python-boilerplates
 COPY --chown=${USER_ID}:${GROUP_ID} requirements*.txt ./
 
 RUN set -Eeuxo pipefail && \
-  pip3 install --no-cache-dir -r requirements_ci.txt && \
-  pip3 uninstall -y boilerplates
+  pip3 install --no-cache-dir -r requirements_ci.txt
 
 # prepare python-boilerplates for testing
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,8 +103,7 @@ pipeline {
           set -Eeuxo pipefail
           python3 -m twine upload \
             dist/${PYTHON_PACKAGE}-${VERSION}-py3-none-any.whl \
-            dist/${PYTHON_PACKAGE}-${VERSION}.tar.gz \
-            dist/${PYTHON_PACKAGE}-${VERSION}.zip
+            dist/${PYTHON_PACKAGE}-${VERSION}.tar.gz
         """
       }
     }
@@ -120,8 +119,7 @@ pipeline {
         script {
           githubUtils.createRelease([
             "dist/${PYTHON_PACKAGE}-${VERSION}-py3-none-any.whl",
-            "dist/${PYTHON_PACKAGE}-${VERSION}.tar.gz",
-            "dist/${PYTHON_PACKAGE}-${VERSION}.zip"
+            "dist/${PYTHON_PACKAGE}-${VERSION}.tar.gz"
             ])
         }
       }

--- a/boilerplates/packaging_tests.py
+++ b/boilerplates/packaging_tests.py
@@ -100,20 +100,34 @@ class PackagingTests(unittest.TestCase):
         expanded_args = expand_args_by_globbing_items('*.py', cwd=pathlib.Path(self.pkg_name))
         self.assertIn('__init__.py', expanded_args)
 
+    def test_setup_help(self):
+        run_module('setup', '--help')
+        # self.assertTrue(os.path.isdir('dist'))
+
     def test_build(self):
         run_program(sys.executable, '-m', 'build')
         self.assertTrue(os.path.isdir('dist'))
 
-    def test_build_binary(self):
-        run_module('setup', 'bdist')
-        self.assertTrue(os.path.isdir('dist'))
+    # def test_build_binary(self):
+    #     run_module('setup', 'bdist')
+    #     self.assertTrue(os.path.isdir('dist'))
 
     def test_build_wheel(self):
-        run_module('setup', 'bdist_wheel')
+        # run_module('setup', 'bdist_wheel')
+        run_module('build', '--wheel')
+        self.assertTrue(os.path.isdir('dist'))
+
+    def test_build_wheel_no_isolation(self):
+        run_module('build', '--wheel', '--no-isolation')
         self.assertTrue(os.path.isdir('dist'))
 
     def test_build_source(self):
-        run_module('setup', 'sdist', '--formats=gztar,zip')
+        # run_module('setup', 'sdist', '--formats=gztar,zip')
+        run_module('build', '--sdist')
+        self.assertTrue(os.path.isdir('dist'))
+
+    def test_build_source_no_isolation(self):
+        run_module('build', '--sdist', '--no-isolation')
         self.assertTrue(os.path.isdir('dist'))
 
     def test_install_code(self):

--- a/boilerplates/packaging_tests.py
+++ b/boilerplates/packaging_tests.py
@@ -141,12 +141,6 @@ class PackagingTests(unittest.TestCase):
                 'install', '--prefix', temporary_folder, f'dist/*-{self.version}.tar.gz', glob=True)
         self.assertFalse(pathlib.Path(temporary_folder).exists())
 
-    def test_install_source_zip(self):
-        with tempfile.TemporaryDirectory() as temporary_folder:
-            run_pip(
-                'install', '--prefix', temporary_folder, f'dist/*-{self.version}.zip', glob=True)
-        self.assertFalse(pathlib.Path(temporary_folder).exists())
-
     def test_install_wheel(self):
         with tempfile.TemporaryDirectory() as temporary_folder:
             run_pip(

--- a/boilerplates/packaging_tests.py
+++ b/boilerplates/packaging_tests.py
@@ -102,18 +102,12 @@ class PackagingTests(unittest.TestCase):
 
     def test_setup_help(self):
         run_module('setup', '--help')
-        # self.assertTrue(os.path.isdir('dist'))
 
     def test_build(self):
         run_program(sys.executable, '-m', 'build')
         self.assertTrue(os.path.isdir('dist'))
 
-    # def test_build_binary(self):
-    #     run_module('setup', 'bdist')
-    #     self.assertTrue(os.path.isdir('dist'))
-
     def test_build_wheel(self):
-        # run_module('setup', 'bdist_wheel')
         run_module('build', '--wheel')
         self.assertTrue(os.path.isdir('dist'))
 
@@ -122,7 +116,6 @@ class PackagingTests(unittest.TestCase):
         self.assertTrue(os.path.isdir('dist'))
 
     def test_build_source(self):
-        # run_module('setup', 'sdist', '--formats=gztar,zip')
         run_module('build', '--sdist')
         self.assertTrue(os.path.isdir('dist'))
 

--- a/boilerplates/packaging_tests.py
+++ b/boilerplates/packaging_tests.py
@@ -130,19 +130,21 @@ class PackagingTests(unittest.TestCase):
 
     def test_install_code(self):
         with tempfile.TemporaryDirectory() as temporary_folder:
-            run_pip('install', '--prefix', temporary_folder, '.')
+            run_pip('install', '--ignore-installed', '--prefix', temporary_folder, '.')
         self.assertFalse(pathlib.Path(temporary_folder).exists())
 
     def test_install_source_tar(self):
         with tempfile.TemporaryDirectory() as temporary_folder:
             run_pip(
-                'install', '--prefix', temporary_folder, f'dist/*-{self.version}.tar.gz', glob=True)
+                'install', '--ignore-installed', '--prefix', temporary_folder,
+                f'dist/*-{self.version}.tar.gz', glob=True)
         self.assertFalse(pathlib.Path(temporary_folder).exists())
 
     def test_install_wheel(self):
         with tempfile.TemporaryDirectory() as temporary_folder:
             run_pip(
-                'install', '--prefix', temporary_folder, f'dist/*-{self.version}-*.whl', glob=True)
+                'install', '--ignore-installed', '--prefix', temporary_folder,
+                f'dist/*-{self.version}-*.whl', glob=True)
         self.assertFalse(pathlib.Path(temporary_folder).exists())
 
     def test_pip_error(self):

--- a/boilerplates/packaging_tests.py
+++ b/boilerplates/packaging_tests.py
@@ -1,6 +1,8 @@
 """Test definitions for package building."""
 
+import contextlib
 import importlib
+import io
 import logging
 import os
 import pathlib
@@ -101,7 +103,10 @@ class PackagingTests(unittest.TestCase):
         self.assertIn('__init__.py', expanded_args)
 
     def test_setup_help(self):
-        run_module('setup', '--help')
+        stdout_buffer = io.StringIO()
+        with contextlib.redirect_stdout(stdout_buffer):
+            run_module('setup', '--help')
+        self.assertIn('usage: setup.py', stdout_buffer.getvalue())
 
     def test_build(self):
         run_program(sys.executable, '-m', 'build')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
+build-backend = 'setuptools.build_meta'
 requires = [
-    'build >= 0.10',
+    'boilerplates[setup] ~= 1.1, >= 1.1.4',
     'docutils ~= 0.20',
     'GitPython ~= 3.1',
     'packaging >= 24.0',
     'Pygments ~= 2.14',
     'semver >= 2.13, < 3.1',
-    'setuptools >= 67.4'
+    'setuptools >= 70.0.3'
 ]
 
 [tool.flake8]

--- a/requirements_ci.txt
+++ b/requirements_ci.txt
@@ -1,4 +1,5 @@
 -r requirements_test.txt
+boilerplates[setup] ~= 1.1, >= 1.1.4
 codecov ~= 2.1
 coverage ~= 7.2
 flake518 ~= 1.6

--- a/requirements_ci.txt
+++ b/requirements_ci.txt
@@ -8,3 +8,4 @@ pylint ~= 3.1
 twine ~= 6.1
 types-docutils ~= 0.20
 types-setuptools >= 70.0
+version-query ~= 1.6

--- a/requirements_packaging_tests.txt
+++ b/requirements_packaging_tests.txt
@@ -1,3 +1,4 @@
 -r requirements_setup.txt
+build ~= 1.2
 pip >= 24.0
 wheel >= 0.43

--- a/requirements_setup.txt
+++ b/requirements_setup.txt
@@ -1,5 +1,3 @@
-build ~= 1.2
 docutils ~= 0.20
 Pygments ~= 2.14
 setuptools >= 77.0.3
-version-query ~= 1.6

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,4 +6,3 @@
 -r requirements_sentry.txt
 -r requirements_cli.txt
 -r requirements_git_repo_tests.txt
-version-query ~= 1.6


### PR DESCRIPTION
* don't run `setup.py` directly in tests
* don't build and test for zip source dist anymore
* don't depend on packages which are not actually needed